### PR TITLE
+tracing implement TraceID handling using swift-distributed-tracing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,18 +51,24 @@ let packageDependencies: [Package.Dependency] = [
     from: "1.20.2"
   ),
   .package(
-    url: "https://github.com/apple/swift-log.git",
-    from: "1.4.4"
+    // url: "https://github.com/apple/swift-log.git",
+    // from: "1.4.4"
+    url: "https://github.com/slashmo/swift-log.git",
+    branch: "feature/baggage"
   ),
   .package(
     url: "https://github.com/apple/swift-argument-parser.git",
     // Version is higher than in other Package@swift manifests: 1.1.0 raised the minimum Swift
-    // version and indluded async support.
+    // version and included async support.
     from: "1.1.1"
   ),
   .package(
     url: "https://github.com/apple/swift-docc-plugin",
     from: "1.0.0"
+  ),
+  .package(
+    url: "https://github.com/apple/swift-distributed-tracing",
+    branch: "main"
   ),
 ].appending(
   .package(
@@ -114,6 +120,7 @@ extension Target.Dependency {
     package: "swift-nio-transport-services"
   )
   static let logging: Self = .product(name: "Logging", package: "swift-log")
+  static let tracing: Self = .product(name: "Tracing", package: "swift-distributed-tracing")
   static let protobuf: Self = .product(name: "SwiftProtobuf", package: "swift-protobuf")
   static let protobufPluginLibrary: Self = .product(
     name: "SwiftProtobufPluginLibrary",
@@ -139,6 +146,7 @@ extension Target {
       .nioHTTP2,
       .nioExtras,
       .logging,
+      .tracing,
       .protobuf,
     ].appending(
       .nioSSL, if: includeNIOSSL

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
@@ -195,7 +195,7 @@ internal final class AsyncServerHandler<
   internal var logger: Logger
 
   /// Contextual baggage which can be used to start tracing spans,
-  // or carry additional contextual information through the handler.
+  /// or carry additional contextual information through the handler.
   @usableFromInline
   internal var baggage: Baggage
 

--- a/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
@@ -16,6 +16,7 @@
 import Logging
 import NIOCore
 import NIOHPACK
+import Tracing
 
 public final class ClientStreamingServerHandler<
   Serializer: MessageSerializer,
@@ -61,6 +62,9 @@ public final class ClientStreamingServerHandler<
   internal var logger: Logger
 
   @usableFromInline
+  internal var baggage: Baggage
+
+  @usableFromInline
   internal enum State {
     // Nothing has happened yet.
     case idle
@@ -91,6 +95,7 @@ public final class ClientStreamingServerHandler<
     let userInfoRef = Ref(UserInfo())
     self.userInfoRef = userInfoRef
     self.logger = context.logger
+    self.baggage = .topLevel
     self.interceptors = ServerInterceptorPipeline(
       logger: context.logger,
       eventLoop: context.eventLoop,
@@ -108,9 +113,17 @@ public final class ClientStreamingServerHandler<
 
   @inlinable
   public func receiveMetadata(_ headers: HPACKHeaders) {
-    if let extractor = self.context.traceIDExtractor, let id = extractor.extract(from: headers) {
-      self.logger[metadataKey: extractor.loggerKey] = "\(id)"
-      self.interceptors.logger[metadataKey: extractor.loggerKey] = "\(id)"
+    if let tracer = self.context.tracer {
+      var baggage = Baggage.topLevel
+      tracer.extract(headers, into: &baggage, using: HPACKHeadersExtractor())
+      self.baggage = baggage
+
+      if let metadata: Logger.Metadata = self.logger.metadataProvider?.metadata(baggage) { // FIXME: function naming a bit ugly here
+        for (k, v) in metadata {
+          self.logger[metadataKey: k] = v
+          self.interceptors?.logger[metadataKey: k] = v
+        }
+      }
     }
     self.interceptors.receive(.metadata(headers))
   }

--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
@@ -143,7 +143,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
       normalizeHeaders: normalizeHeaders,
       maximumReceiveMessageLength: self.configuration.maximumReceiveMessageLength,
       logger: logger,
-      traceIDExtractor: self.configuration.traceIDExtractor
+      tracer: self.configuration.tracer
     )
   }
 

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -19,6 +19,7 @@ import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2
 import SwiftProtobuf
+import Tracing
 
 /// Provides ``GRPCServerHandlerProtocol`` objects for the methods on a particular service name.
 ///
@@ -45,6 +46,7 @@ public struct CallHandlerContext {
   internal var errorDelegate: ServerErrorDelegate?
   @usableFromInline
   internal var logger: Logger
+  // TODO: does this need baggage?
   @usableFromInline
   internal var encoding: ServerMessageEncoding
   @usableFromInline
@@ -60,7 +62,7 @@ public struct CallHandlerContext {
   @usableFromInline
   internal var closeFuture: EventLoopFuture<Void>
   @usableFromInline
-  internal var traceIDExtractor: Server.Configuration.TraceIDExtractor?
+  internal var tracer: Tracing.Tracer?
 }
 
 /// A call URI split into components.

--- a/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
@@ -17,13 +17,14 @@ import Logging
 import NIOCore
 import NIOHPACK
 import NIOHTTP2
+import Tracing
 
 internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServerResponseWriter {
   typealias InboundIn = HTTP2Frame.FramePayload
   typealias OutboundOut = HTTP2Frame.FramePayload
 
   private var logger: Logger
-  private let traceIDExtractor: Server.Configuration.TraceIDExtractor?
+  private var tracer: Tracing.Tracer?
   private var state: HTTP2ToRawGRPCStateMachine
   private let errorDelegate: ServerErrorDelegate?
   private var context: ChannelHandlerContext!
@@ -75,10 +76,10 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
     normalizeHeaders: Bool,
     maximumReceiveMessageLength: Int,
     logger: Logger,
-    traceIDExtractor: Server.Configuration.TraceIDExtractor?
+    tracer: Tracing.Tracer?
   ) {
     self.logger = logger
-    self.traceIDExtractor = traceIDExtractor
+    self.tracer = tracer
     self.errorDelegate = errorDelegate
     self.servicesByName = servicesByName
     self.encoding = encoding
@@ -131,7 +132,7 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
         services: self.servicesByName,
         encoding: self.encoding,
         normalizeHeaders: self.normalizeHeaders,
-        traceIDExtractor: self.traceIDExtractor
+        tracer: self.tracer
       )
 
       switch receiveHeaders {

--- a/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
@@ -17,6 +17,7 @@ import Logging
 import NIOCore
 import NIOHPACK
 import NIOHTTP2
+import Tracing
 
 struct HTTP2ToRawGRPCStateMachine {
   /// The current state.
@@ -278,7 +279,7 @@ extension HTTP2ToRawGRPCStateMachine.State {
     services: [Substring: CallHandlerProvider],
     encoding: ServerMessageEncoding,
     normalizeHeaders: Bool,
-    traceIDExtractor: Server.Configuration.TraceIDExtractor?
+    tracer: Tracing.Tracer?
   ) -> HTTP2ToRawGRPCStateMachine.StateAndReceiveHeadersAction {
     // Extract and validate the content type. If it's nil we need to close.
     guard let contentType = self.extractContentType(from: headers) else {
@@ -328,7 +329,7 @@ extension HTTP2ToRawGRPCStateMachine.State {
       responseWriter: responseWriter,
       allocator: allocator,
       closeFuture: closeFuture,
-      traceIDExtractor: traceIDExtractor
+      tracer: tracer
     )
 
     // We have a matching service, hopefully we have a provider for the method too.
@@ -868,7 +869,7 @@ extension HTTP2ToRawGRPCStateMachine {
     services: [Substring: CallHandlerProvider],
     encoding: ServerMessageEncoding,
     normalizeHeaders: Bool,
-    traceIDExtractor: Server.Configuration.TraceIDExtractor?
+    tracer: Tracing.Tracer?
   ) -> ReceiveHeadersAction {
     return self.withStateAvoidingCoWs { state in
       state.receive(
@@ -883,7 +884,7 @@ extension HTTP2ToRawGRPCStateMachine {
         services: services,
         encoding: encoding,
         normalizeHeaders: normalizeHeaders,
-        traceIDExtractor: traceIDExtractor
+        tracer: tracer
       )
     }
   }
@@ -979,7 +980,7 @@ extension HTTP2ToRawGRPCStateMachine.State {
     services: [Substring: CallHandlerProvider],
     encoding: ServerMessageEncoding,
     normalizeHeaders: Bool,
-    traceIDExtractor: Server.Configuration.TraceIDExtractor?
+    tracer: Tracing.Tracer?
   ) -> HTTP2ToRawGRPCStateMachine.ReceiveHeadersAction {
     switch self {
     // These are the only states in which we can receive headers. Everything else is invalid.
@@ -997,7 +998,7 @@ extension HTTP2ToRawGRPCStateMachine.State {
         services: services,
         encoding: encoding,
         normalizeHeaders: normalizeHeaders,
-        traceIDExtractor: traceIDExtractor
+        tracer: tracer
       )
       self = stateAndAction.state
       return stateAndAction.action

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -179,20 +179,15 @@ extension Server.Builder {
   /// Extracts the value present in the request headers for the header field named `headerName` and
   /// inserts it as metadata into the logger for the RPC using the key `loggerKey`.
   @discardableResult
+  @available(*, deprecated, message: "Arguably one should rather configure a tracing backend, but yes we can allow setting a tracer")
   public func withFixedHeaderTraceIDExtraction(headerName: String, loggerKey: String) -> Self {
-    self.configuration.traceIDExtractor = .fixedHeaderName(headerName, loggerKey: loggerKey)
+    self.configuration.tracer = _GRPCSimpleFixedTraceIDTracer(fixedHeaderName: headerName)
     return self
   }
 
-  /// Extracts a trace ID using the given function for each RPC and sets it as a metadata value
-  /// on the logger using the key `loggerKey`.
-  public func withTraceIDExtraction(
-    loggerKey: String,
-    extractor: @escaping (HPACKHeaders) -> String?
-  ) -> Self {
-    self.configuration.traceIDExtractor = .init(loggerKey: loggerKey, extractor: extractor)
-    return self
-  }
+  // NOTE: Don't do APIs which do -> String, because there may be more interesting values to extract than one,
+  //       Implementing a -> Baggage is how tracers are implemented;
+  //       We should not be providing "partial" tracer implementations INSIDE client libraries, that's what tracer libraries are for.
 }
 
 extension Server.Builder {

--- a/Sources/GRPC/TracingSupport.swift
+++ b/Sources/GRPC/TracingSupport.swift
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Tracing
+import NIOHPACK
+import Dispatch
+
+@usableFromInline
+struct HPACKHeadersExtractor: Tracing.Extractor {
+
+  @usableFromInline
+  init() {}
+
+  @usableFromInline
+  func extract(key: String, from headers: HPACKHeaders) -> String? {
+    headers.first(name: key)
+  }
+}
+
+@usableFromInline
+struct HPACKHeadersInjector: Tracing.Injector {
+
+  @usableFromInline
+  init() {}
+
+  @usableFromInline
+  func inject(_ value: String, forKey key: String, into headers: inout HPACKHeaders) {
+    headers.add(name: key, value: value)
+  }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+
+@available(*, deprecated, message: "Arguably the *real* package should not have such keys declared... but we can push on this a bit I guess")
+public struct _GRPCSimpleFixedTraceIDTracer: Tracer {
+  typealias Carrier = HPACKHeaders
+  public let fixedHeaderName: String
+
+  public init(fixedHeaderName: String) {
+    self.fixedHeaderName = fixedHeaderName
+  }
+
+  public func startSpan(_ operationName: String, baggage: Baggage, ofKind kind: SpanKind, at time: Dispatch.DispatchWallTime) -> Span {
+    fatalError("startSpan(_:baggage:ofKind:at:) has not been implemented")
+  }
+
+  public func forceFlush() {
+  }
+
+  public func extract<Carrier, Extract>(_ headers: Carrier,
+                                 into baggage: inout Baggage,
+                                 using extractor: Extract)
+      where Extract: Extractor, Extract.Carrier == Carrier {
+    if let value = extractor.extract(key: self.fixedHeaderName, from: headers) {
+      print("Extracted: \(value)")
+      baggage.grpcSimpleFixedTraceID = value
+    }
+  }
+
+  public func inject<Carrier, Inject>(_ baggage: Baggage,
+                               into headers: inout Carrier,
+                               using injector: Inject)
+      where Inject: Injector, Inject.Carrier == Carrier {
+    if let value = baggage.grpcSimpleFixedTraceID {
+      print("Injected: \(value)")
+      injector.inject(value, forKey: self.fixedHeaderName, into: &headers)
+    }
+  }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+
+@available(*, deprecated, message: "Arguably the *real* package should not have such keys declared... but we can push on this a bit I guess")
+enum GRPCSimpleFixedTraceID: BaggageKey {
+  typealias Value = String
+  static var nameOverride: String? { "grpc-simple-trace-id" }
+}
+
+extension Baggage {
+  /// Simple `trace-id` without the need of using actual complete Tracer implementation.
+  @available(*, deprecated, message: "Arguably the *real* package should not have such keys declared... but we can push on this a bit I guess")
+  public internal(set) var grpcSimpleFixedTraceID: String? {
+    get {
+      self[GRPCSimpleFixedTraceID.self]
+    }
+    set {
+      self[GRPCSimpleFixedTraceID.self] = newValue
+    }
+  }
+}

--- a/Sources/GRPC/_EmbeddedThroughput.swift
+++ b/Sources/GRPC/_EmbeddedThroughput.swift
@@ -54,7 +54,7 @@ extension EmbeddedChannel {
       normalizeHeaders: normalizeHeaders,
       maximumReceiveMessageLength: .max,
       logger: logger,
-      traceIDExtractor: nil
+      tracer: nil
     )
     return self.pipeline.addHandler(codec)
   }

--- a/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
@@ -56,7 +56,7 @@ class AsyncServerHandlerTests: GRPCTestCase {
       responseWriter: self.recorder,
       allocator: ByteBufferAllocator(),
       closeFuture: closeFuture,
-      traceIDExtractor: nil
+      tracer: nil
     )
   }
 

--- a/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
+++ b/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
@@ -109,7 +109,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: services ?? self.services,
       encoding: encoding,
       normalizeHeaders: true,
-      traceIDExtractor: nil
+      tracer: nil
     )
 
     assertThat(receiveHeadersAction, .is(.configure()))
@@ -186,7 +186,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .disabled,
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
     assertThat(action, .is(.configure()))
   }
@@ -205,7 +205,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .disabled,
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
     assertThat(action, .is(.rejectRPC(.contains(":status", ["415"]))))
   }
@@ -224,7 +224,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .disabled,
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
     assertThat(action, .is(.rejectRPC(.trailersOnly(code: .unimplemented))))
   }
@@ -243,7 +243,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .disabled,
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
     assertThat(action, .is(.rejectRPC(.trailersOnly(code: .unimplemented))))
   }
@@ -262,7 +262,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .disabled,
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
     assertThat(action, .is(.rejectRPC(.trailersOnly(code: .unimplemented))))
   }
@@ -281,7 +281,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .disabled,
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
     assertThat(action, .is(.rejectRPC(.trailersOnly(code: .unimplemented))))
   }
@@ -301,7 +301,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .disabled,
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
     assertThat(action, .is(.rejectRPC(.trailersOnly(code: .invalidArgument))))
   }
@@ -321,7 +321,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .enabled(.deflate, .identity),
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
 
     assertThat(action, .is(.rejectRPC(.trailersOnly(code: .unimplemented))))
@@ -347,7 +347,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .enabled(.deflate, .identity),
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
 
     // This is expected: however, we also expect 'grpc-accept-encoding' to be in the response
@@ -376,7 +376,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .disabled,
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
 
     assertThat(action, .is(.configure()))
@@ -397,7 +397,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       services: self.services,
       encoding: .enabled(.gzip, .deflate),
       normalizeHeaders: false,
-      traceIDExtractor: nil
+      tracer: nil
     )
 
     // This is expected, but we need to check the value of 'grpc-encoding' in the response headers.

--- a/Tests/GRPCTests/ServerErrorDelegateTests.swift
+++ b/Tests/GRPCTests/ServerErrorDelegateTests.swift
@@ -161,7 +161,7 @@ class ServerErrorDelegateTests: GRPCTestCase {
       normalizeHeaders: true,
       maximumReceiveMessageLength: .max,
       logger: self.logger,
-      traceIDExtractor: nil
+      tracer: nil
     )
 
     self.channel = EmbeddedChannel(handler: handler)


### PR DESCRIPTION
This PR uses https://github.com/apple/swift-distributed-tracing to implement the trace id functionality.

We can polish it up a bit, release the 1.0 tracing lib and then grpc would be able to participate in any kind of baggage propagation 🎉 